### PR TITLE
Read and write settings at the project level

### DIFF
--- a/DevToolsCore/DevToolsCore.h
+++ b/DevToolsCore/DevToolsCore.h
@@ -1,5 +1,6 @@
 #import <DevToolsCore/PBXBuildFile.h>
 #import <DevToolsCore/PBXBuildPhase.h>
+#import <DevToolsCore/PBXBuildStyle.h>
 #import <DevToolsCore/PBXContainer.h>
 #import <DevToolsCore/PBXGroup.h>
 #import <DevToolsCore/PBXProject.h>

--- a/DevToolsCore/PBXBuildStyle.h
+++ b/DevToolsCore/PBXBuildStyle.h
@@ -1,0 +1,9 @@
+@protocol PBXBuildStyle <NSObject>
+
+- (id)buildSettings;
+
+- (id)buildSettingForKeyPath:(id)arg1;
+
+- (void)setBuildSetting:(id)arg1 forKeyPath:(id)arg2;
+
+@end

--- a/DevToolsCore/XCBuildConfiguration.h
+++ b/DevToolsCore/XCBuildConfiguration.h
@@ -1,6 +1,7 @@
 #import "PBXFileReference.h"
+#import "PBXBuildStyle.h"
 
-@protocol XCBuildConfiguration <NSObject>
+@protocol XCBuildConfiguration <PBXBuildStyle, NSObject>
 
 + (BOOL) fileReference:(id<PBXFileReference>)reference isValidBaseConfigurationFile:(NSError **)error;
 

--- a/DevToolsCore/XCConfigurationList.h
+++ b/DevToolsCore/XCConfigurationList.h
@@ -5,4 +5,6 @@
 
 - (NSArray<XCBuildConfiguration> *) buildConfigurations;
 
+- (id)buildSettingDictionariesForConfigurationName:(id)arg1 errors:(id *)arg2;
+
 @end

--- a/xcproj.xcodeproj/project.pbxproj
+++ b/xcproj.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		08FB7796FE84155DC02AAC07 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Sources/main.m; sourceTree = "<group>"; };
 		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		32A70AAB03705E1F00C91783 /* xcproj_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = xcproj_Prefix.pch; path = Sources/xcproj_Prefix.pch; sourceTree = "<group>"; };
+		662666101A902A1A0028214C /* PBXBuildStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBXBuildStyle.h; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* xcproj */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = xcproj; sourceTree = BUILT_PRODUCTS_DIR; };
 		C215308419DBE040002524A7 /* XMLPlistDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMLPlistDecoder.h; path = Sources/XMLPlistDecoder.h; sourceTree = "<group>"; };
 		C215308519DBE040002524A7 /* XMLPlistDecoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMLPlistDecoder.m; path = Sources/XMLPlistDecoder.m; sourceTree = "<group>"; };
@@ -145,6 +146,7 @@
 				DA8CA0041302B0D9008B3560 /* DevToolsCore.h */,
 				DA8CA0301302B27C008B3560 /* PBXBuildFile.h */,
 				DA8C9FFC1302AF93008B3560 /* PBXBuildPhase.h */,
+				662666101A902A1A0028214C /* PBXBuildStyle.h */,
 				DA7A018E134F015F00F89E9B /* PBXContainer.h */,
 				DA7A08AD134F4C1600F89E9B /* PBXFileReference.h */,
 				DA7A018F134F01DE00F89E9B /* PBXGroup.h */,


### PR DESCRIPTION
Hi Cédric,

I added a couple of actions to xcproj to be able to work with settings at the project level, which I found specially useful when they have several targets.

For example, I'm using xcproj to set CFBundleVersion to the commits count automatically each time I do a release build. As this value is the same for all targets, I can now set it at the project level and use $(GIT_COMMITS_COUNT) or something like that in each one to avoid redundancy and the values getting out of sync.

Do you think other users might find this useful?

Please let me know if it needs any improvements (the naming of the actions might not be the best I reckon).
I tried to keep as close as possible to the coding style, and tested it with both Xcode 5 and 6.

Cheers!
