### PR TITLE
Support Xcode 7.3 beta

### DIFF
--- a/DevToolsCore/PBXProject.h
+++ b/DevToolsCore/PBXProject.h
@@ -13,7 +13,7 @@
 
 - (id<XCConfigurationList>) buildConfigurationList;
 
-- (NSString *) expandedValueForString:(NSString *)string forBuildParameters:(id<IDEMutableBuildParameters>)buildParameters;
+- (NSString *) expandedValueForString:(NSString *)string forBuildParameters:(id<IDEBuildParameters>)buildParameters;
 
 - (BOOL) writeToFileSystemProjectFile:(BOOL)projectWrite userFile:(BOOL)userWrite checkNeedsRevert:(BOOL)checkNeedsRevert;
 

--- a/DevToolsCore/PBXProject.h
+++ b/DevToolsCore/PBXProject.h
@@ -13,7 +13,7 @@
 
 - (id<XCConfigurationList>) buildConfigurationList;
 
-- (NSString *) expandedValueForString:(NSString *)string forBuildParameters:(id<IDEMutableBuildParameters>)buildParameters withFallbackConfigurationName:(NSString *)fallbackConfigurationName;
+- (NSString *) expandedValueForString:(NSString *)string forBuildParameters:(id<IDEMutableBuildParameters>)buildParameters;
 
 - (BOOL) writeToFileSystemProjectFile:(BOOL)projectWrite userFile:(BOOL)userWrite checkNeedsRevert:(BOOL)checkNeedsRevert;
 

--- a/DevToolsCore/PBXTarget.h
+++ b/DevToolsCore/PBXTarget.h
@@ -1,6 +1,6 @@
 #import "PBXBuildPhase.h"
 #import "XCConfigurationList.h"
-#import "IDEMutableBuildParameters.h"
+#import "IDEBuildParameters.h"
 
 @protocol PBXTarget <NSObject>
 
@@ -8,7 +8,7 @@
 
 - (id<XCConfigurationList>) buildConfigurationList;
 
-- (NSString *) expandedValueForString:(NSString *)string forBuildParameters:(id<IDEMutableBuildParameters>)buildParameters;
+- (NSString *) expandedValueForString:(NSString *)string forBuildParameters:(id<IDEBuildParameters>)buildParameters;
 
 - (void) setBuildSetting:(NSString *)buildSetting forKeyPath:(NSString *)keyPath;
 

--- a/IDEFoundation/IDEBuildParameters.h
+++ b/IDEFoundation/IDEBuildParameters.h
@@ -1,0 +1,5 @@
+@protocol IDEBuildParameters <NSObject>
+
+- (id<IDEBuildParameters>)initForBuildWithConfigurationName:(NSString *)configurationName;
+
+@end

--- a/IDEFoundation/IDEFoundation.h
+++ b/IDEFoundation/IDEFoundation.h
@@ -1,1 +1,1 @@
-#import <IDEFoundation/IDEMutableBuildParameters.h>
+#import <IDEFoundation/IDEBuildParameters.h>

--- a/IDEFoundation/IDEMutableBuildParameters.h
+++ b/IDEFoundation/IDEMutableBuildParameters.h
@@ -1,6 +1,0 @@
-
-@protocol IDEMutableBuildParameters <NSObject>
-
-- (void) setConfigurationName:(NSString *)configurationName;
-
-@end

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -27,13 +27,13 @@ static Class PBXGroup = Nil;
 static Class PBXProject = Nil;
 static Class PBXReference = Nil;
 static Class XCBuildConfiguration = Nil;
-static Class IDEMutableBuildParameters = Nil;
+static Class IDEBuildParameters = Nil;
 
 + (void) setPBXGroup:(Class)class                  { PBXGroup = class; }
 + (void) setPBXProject:(Class)class                { PBXProject = class; }
 + (void) setPBXReference:(Class)class              { PBXReference = class; }
 + (void) setXCBuildConfiguration:(Class)class      { XCBuildConfiguration = class; }
-+ (void) setIDEMutableBuildParameters:(Class)class { IDEMutableBuildParameters = class; }
++ (void) setIDEBuildParameters:(Class)class        { IDEBuildParameters = class; }
 + (void) setValue:(id)value forUndefinedKey:(NSString *)key { /* ignore */ }
 
 static NSString *XcodeBundleIdentifier = @"com.apple.dt.Xcode";
@@ -202,7 +202,7 @@ static void WorkaroundRadar18512876(void)
 	                       @protocol(PBXTarget),
 	                       @protocol(XCBuildConfiguration),
 	                       @protocol(XCConfigurationList),
-	                       @protocol(IDEMutableBuildParameters)];
+	                       @protocol(IDEBuildParameters)];
 	
 	for (Protocol *protocol in protocols)
 	{
@@ -441,9 +441,8 @@ static void WorkaroundRadar18512876(void)
 	
 	NSString *buildSetting = [arguments objectAtIndex:0];
 	NSString *settingString = [NSString stringWithFormat:@"$(%@)", buildSetting];
-	id<IDEMutableBuildParameters> buildParameters = [IDEMutableBuildParameters new];
 	NSString *configurationName = _configurationName ?: [[_project buildConfigurationList] defaultConfigurationName];
-	[buildParameters setConfigurationName:configurationName];
+	id<IDEBuildParameters> buildParameters = [[IDEBuildParameters alloc] initForBuildWithConfigurationName:configurationName];
 	NSString *expandedString;
 	if (_target)
 		expandedString = [_target expandedValueForString:settingString forBuildParameters:buildParameters];

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -102,7 +102,8 @@ static void LoadXcodeFrameworks(NSBundle *xcodeBundle)
 		// Xcode 5 requires DVTFoundation, CSServiceClient, IDEFoundation and Xcode3Core
 		// Xcode 6 requires DVTFoundation, DVTSourceControl, IDEFoundation and Xcode3Core
 		// Xcode 7 requires DVTFoundation, DVTSourceControl, IBFoundation, IBAutolayoutFoundation, IDEFoundation and Xcode3Core
-		frameworks = @[ @"DVTFoundation.framework", @"DVTSourceControl.framework", @"CSServiceClient.framework", @"IBFoundation.framework", @"IBAutolayoutFoundation.framework", @"IDEFoundation.framework", @"Xcode3Core.ideplugin" ];
+		// Xcode 7.3 requires DVTFoundation, DVTSourceControl, DVTServices, DVTPortal, IBFoundation, IBAutolayoutFoundation, IDEFoundation and Xcode3Core
+		frameworks = @[ @"DVTFoundation.framework", @"DVTSourceControl.framework", @"DVTServices.framework", @"DVTPortal.framework", @"CSServiceClient.framework", @"IBFoundation.framework", @"IBAutolayoutFoundation.framework", @"IDEFoundation.framework", @"Xcode3Core.ideplugin" ];
 	}
 	
 	for (NSString *framework in frameworks)

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -50,6 +50,25 @@ static NSBundle * XcodeBundle(void)
 	NSBundle *xcodeBundle = XcodeBundleAtPath(xcodeAppPath);
 	if (!xcodeBundle)
 	{
+		NSTask *task = [NSTask new];
+		task.launchPath = @"/usr/bin/xcode-select";
+		task.arguments = @[@"--print-path"];
+		task.standardOutput = [NSPipe new];
+
+		[task launch];
+		[task waitUntilExit];
+
+		if (task.terminationStatus == 0)
+		{
+			NSData *outputData = [[task.standardOutput fileHandleForReading] readDataToEndOfFile];
+			NSString *outputString = [[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding];
+			NSString *xcodePath = [[outputString stringByDeletingLastPathComponent] stringByDeletingLastPathComponent];
+			xcodeBundle = XcodeBundleAtPath(xcodePath);
+		}
+	}
+
+	if (!xcodeBundle)
+	{
 		NSURL *xcodeURL = [[NSWorkspace sharedWorkspace] URLForApplicationWithBundleIdentifier:XcodeBundleIdentifier];
 		xcodeBundle = XcodeBundleAtPath(xcodeURL.path);
 	}

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -82,6 +82,7 @@ static void LoadXcodeFrameworks(NSBundle *xcodeBundle)
 	{
 		// Xcode 5 requires DVTFoundation, CSServiceClient, IDEFoundation and Xcode3Core
 		// Xcode 6 requires DVTFoundation, DVTSourceControl, IDEFoundation and Xcode3Core
+		// Xcode 7 requires DVTFoundation, DVTSourceControl, IBFoundation, IBAutolayoutFoundation, IDEFoundation and Xcode3Core
 		frameworks = @[ @"DVTFoundation.framework", @"DVTSourceControl.framework", @"CSServiceClient.framework", @"IBFoundation.framework", @"IBAutolayoutFoundation.framework", @"IDEFoundation.framework", @"Xcode3Core.ideplugin" ];
 	}
 	

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -428,7 +428,7 @@ static void WorkaroundRadar18512876(void)
 	if (_target)
 		expandedString = [_target expandedValueForString:settingString forBuildParameters:buildParameters];
 	else
-		expandedString = [_project expandedValueForString:settingString forBuildParameters:buildParameters withFallbackConfigurationName:nil];
+		expandedString = [_project expandedValueForString:settingString forBuildParameters:buildParameters];
 	
 	if ([expandedString length] > 0)
 		ddprintf(@"%@\n", expandedString);

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -82,7 +82,7 @@ static void LoadXcodeFrameworks(NSBundle *xcodeBundle)
 	{
 		// Xcode 5 requires DVTFoundation, CSServiceClient, IDEFoundation and Xcode3Core
 		// Xcode 6 requires DVTFoundation, DVTSourceControl, IDEFoundation and Xcode3Core
-		frameworks = @[ @"DVTFoundation.framework", @"DVTSourceControl.framework", @"CSServiceClient.framework", @"IDEFoundation.framework", @"Xcode3Core.ideplugin" ];
+		frameworks = @[ @"DVTFoundation.framework", @"DVTSourceControl.framework", @"CSServiceClient.framework", @"IBFoundation.framework", @"IBAutolayoutFoundation.framework", @"IDEFoundation.framework", @"Xcode3Core.ideplugin" ];
 	}
 	
 	for (NSString *framework in frameworks)
@@ -136,7 +136,7 @@ static void InitializeXcodeFrameworks(void)
 	// Xcode3Core.ideplugin`-[Xcode3CommandLineBuildTool run] calls IDEInitialize(NSClassFromString(@"NSApplication") == nil, &error)
 	IDEInitialize(1, NULL);
 	// DevToolsCore`+[PBXProject projectWithFile:errorHandler:readOnly:] calls XCInitializeCoreIfNeeded(NSClassFromString(@"NSApplication") == nil)
-	XCInitializeCoreIfNeeded(1);
+	XCInitializeCoreIfNeeded(0);
 	fflush(stderr);
 	dup2(saved_stderr, STDERR_FILENO);
 	close(saved_stderr);

--- a/xcproj.xcodeproj/project.pbxproj
+++ b/xcproj.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		32A70AAB03705E1F00C91783 /* xcproj_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = xcproj_Prefix.pch; path = Sources/xcproj_Prefix.pch; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* xcproj */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = xcproj; sourceTree = BUILT_PRODUCTS_DIR; };
-		C20F5C151A92A57A004ADE6B /* IDEMutableBuildParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEMutableBuildParameters.h; sourceTree = "<group>"; };
+		C20F5C151A92A57A004ADE6B /* IDEBuildParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEBuildParameters.h; sourceTree = "<group>"; };
 		C20F5C161A92A5F4004ADE6B /* IDEFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEFoundation.h; sourceTree = "<group>"; };
 		C20F5C171A93505D004ADE6B /* PBXBuildStyle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBXBuildStyle.h; sourceTree = "<group>"; };
 		C215308419DBE040002524A7 /* XMLPlistDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMLPlistDecoder.h; path = Sources/XMLPlistDecoder.h; sourceTree = "<group>"; };
@@ -122,7 +122,7 @@
 		C20F5C141A92A57A004ADE6B /* IDEFoundation */ = {
 			isa = PBXGroup;
 			children = (
-				C20F5C151A92A57A004ADE6B /* IDEMutableBuildParameters.h */,
+				C20F5C151A92A57A004ADE6B /* IDEBuildParameters.h */,
 				C20F5C161A92A5F4004ADE6B /* IDEFoundation.h */,
 			);
 			path = IDEFoundation;

--- a/xcproj.xcodeproj/project.pbxproj
+++ b/xcproj.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 			);
 			name = xcproj;
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		08FB7795FE84155DC02AAC07 /* Sources */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This change build's on @amattila's work linking against Xcode 7 frameworks in #11 (which should be merged before this).

The method `-[PBXProject expandedValueForString:forBuildParameters:withFallbackConfigurationName:]` appears to have lost its `withFallbackConfigurationName:` parameter.  This change to the protocol resolves the error reported by `XCDUndocumentedChecker`.

Additionally, the `IDEMutableBuildParameters` class has been replaced by `IDEBuildParameters`.
